### PR TITLE
Rename arm and gripper controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Testing servo 1...
 Send a test trajectory to move the physical arm:
 
 ```bash
-ros2 action send_goal /so_100_arm_controller/follow_joint_trajectory control_msgs/action/FollowJointTrajectory "{
+ros2 action send_goal /arm_controller/follow_joint_trajectory control_msgs/action/FollowJointTrajectory "{
   trajectory: {
     joint_names: [Shoulder_Rotation, Shoulder_Pitch, Elbow, Wrist_Pitch, Wrist_Roll],
     points: [

--- a/config/controllers.yaml
+++ b/config/controllers.yaml
@@ -5,13 +5,13 @@ controller_manager:
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
     
-    so_100_arm_controller:
+    arm_controller:
       type: joint_trajectory_controller/JointTrajectoryController
 
-    so_100_arm_gripper_controller:
+    gripper_controller:
       type: position_controllers/JointGroupPositionController
 
-so_100_arm_controller:
+arm_controller:
   ros__parameters:
     joints:
       - Shoulder_Rotation
@@ -40,7 +40,7 @@ so_100_arm_controller:
           trajectory: 0.05
           goal: 0.03
 
-so_100_arm_gripper_controller:
+gripper_controller:
   ros__parameters:
     joints:
       - Gripper

--- a/launch/hardware.launch.py
+++ b/launch/hardware.launch.py
@@ -67,14 +67,14 @@ def generate_launch_description():
     robot_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["so_100_arm_controller", "-c", "/controller_manager"],
+        arguments=["arm_controller", "-c", "/controller_manager"],
         output="screen",
     )
 
     gripper_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["so_100_arm_gripper_controller", "-c", "/controller_manager"],
+        arguments=["gripper_controller", "-c", "/controller_manager"],
         output="screen",
     )
 


### PR DESCRIPTION
Use shorter names for arm and gripper controllers.

- Use /arm_controller for the joint_trajectory_controller/JointTrajectoryController.
- Use /gripper_controller for the position_controllers/JointGroupPositionController

Sync with upstream: https://github.com/brukg/so_arm_100_hardware/pull/7

Relates to: #12 

