### PR TITLE
Add environment hooks for Gazebo

### DIFF
--- a/so_arm_100_description/CMakeLists.txt
+++ b/so_arm_100_description/CMakeLists.txt
@@ -26,6 +26,13 @@ install(DIRECTORY gazebo launch models ros2_control rviz urdf
 )
 
 ################################################################################
+# Environment hooks
+################################################################################
+
+ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/hooks/${PROJECT_NAME}.dsv.in")
+ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/hooks/${PROJECT_NAME}.sh.in")
+
+################################################################################
 # Macro for ament package
 ################################################################################
 ament_package()

--- a/so_arm_100_description/hooks/so_arm_100_description.dsv.in
+++ b/so_arm_100_description/hooks/so_arm_100_description.dsv.in
@@ -1,0 +1,5 @@
+prepend-non-duplicate;GZ_SIM_RESOURCE_PATH;share;@CMAKE_INSTALL_PREFIX@/share
+prepend-non-duplicate;GZ_SIM_RESOURCE_PATH;share/@PROJECT_NAME@/models
+
+prepend-non-duplicate;SDF_PATH;share;@CMAKE_INSTALL_PREFIX@/share
+prepend-non-duplicate;SDF_PATH;share/@PROJECT_NAME@/models

--- a/so_arm_100_description/hooks/so_arm_100_description.sh.in
+++ b/so_arm_100_description/hooks/so_arm_100_description.sh.in
@@ -1,0 +1,3 @@
+ament_prepend_unique_value GZ_SIM_RESOURCE_PATH "$AMENT_CURRENT_PREFIX/share/@PROJECT_NAME@/models"
+
+ament_prepend_unique_value SDF_PATH "$AMENT_CURRENT_PREFIX/share/@PROJECT_NAME@/models"


### PR DESCRIPTION
Add environment hooks to add the path to `so_100_arm_description/models` directory to `GZ_SIM_RESOURCE_PATH` and `SDF_PATH` when sourcing the workspace `./install/setup.bash` script.

This is useful for other projects that reference the `so_100_arm_description` package and need to resolve the location of mesh files etc. without using a full ROS 2 environment.

For example it is possible to generate SDF directly from `so_arm_100_5dof_arm.urdf.xacro` using a Python script that first runs `xacro.process_file` to output `so_arm_100.urdf`  and then runs `gz sdf -p so_arm_100.urdf`. In order for `gz sim` to resolve the mesh files referenced in the generated sdf the locations must be added to `GZ_SIM_RESOURCE_PATH`.

The `SDF_PATH` is updated to support the tools [`sdformat_urdf`](https://github.com/ros/sdformat_urdf) and [`sdf_to_urdf`](https://github.com/andreasBihlmaier/sdf_to_urdf).
