### PR TITLE
Add option to set initial positions in Gazebo joint controllers

### DIFF
--- a/so_arm_100_description/gazebo/so_arm_100_5dof.gazebo.xacro
+++ b/so_arm_100_description/gazebo/so_arm_100_5dof.gazebo.xacro
@@ -1,12 +1,16 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="so_arm_100_5dof_gazebo" params="prefix ros2_controllers_file:=^|'' use_topic_hardware_interface:=^|false">
+  <xacro:macro name="so_arm_100_5dof_gazebo" params="prefix initial_positions_file:=^|'' ros2_controllers_file:=^|'' use_topic_hardware_interface:=^|false">
   <!--
   Parameters
       prefix: prefix for joints and links
+      initial_positions_file: initial positions file for joints
       ros2_controllers_file: ros2_controller configuration file for gz_ros2_control
       use_topic_hardware_interface: true if using topic based control
   -->
+  <xacro:if value="${initial_positions_file != ''}">
+      <xacro:property name="initial_positions" value="${xacro.load_yaml(initial_positions_file)['initial_positions']}"/>
+  </xacro:if>
 
   <gazebo>
     <plugin name="gz::sim::systems::JointStatePublisher"
@@ -56,6 +60,9 @@
         <i_min>-1</i_min>
         <cmd_max>100.0</cmd_max>
         <cmd_min>-100.0</cmd_min>
+        <xacro:if value="${initial_positions_file != ''}">
+          <initial_position>${initial_positions['Shoulder_Rotation']}</initial_position>
+        </xacro:if>
       </plugin>
       <plugin name="gz::sim::systems::JointPositionController"
         filename="gz-sim-joint-position-controller-system">
@@ -68,6 +75,9 @@
         <i_min>-1</i_min>
         <cmd_max>100.0</cmd_max>
         <cmd_min>-100.0</cmd_min>
+        <xacro:if value="${initial_positions_file != ''}">
+          <initial_position>${initial_positions['Shoulder_Pitch']}</initial_position>
+        </xacro:if>
       </plugin>
       <plugin name="gz::sim::systems::JointPositionController"
         filename="gz-sim-joint-position-controller-system">
@@ -80,6 +90,9 @@
         <i_min>-1</i_min>
         <cmd_max>100.0</cmd_max>
         <cmd_min>-100.0</cmd_min>
+        <xacro:if value="${initial_positions_file != ''}">
+          <initial_position>${initial_positions['Elbow']}</initial_position>
+        </xacro:if>
       </plugin>
       <plugin name="gz::sim::systems::JointPositionController"
         filename="gz-sim-joint-position-controller-system">
@@ -92,6 +105,9 @@
         <i_min>-1</i_min>
         <cmd_max>100.0</cmd_max>
         <cmd_min>-100.0</cmd_min>
+        <xacro:if value="${initial_positions_file != ''}">
+          <initial_position>${initial_positions['Wrist_Pitch']}</initial_position>
+        </xacro:if>
       </plugin>
       <plugin name="gz::sim::systems::JointPositionController"
         filename="gz-sim-joint-position-controller-system">
@@ -104,6 +120,9 @@
         <i_min>-1</i_min>
         <cmd_max>100.0</cmd_max>
         <cmd_min>-100.0</cmd_min>
+        <xacro:if value="${initial_positions_file != ''}">
+          <initial_position>${initial_positions['Wrist_Roll']}</initial_position>
+        </xacro:if>
       </plugin>
       <plugin name="gz::sim::systems::JointPositionController"
         filename="gz-sim-joint-position-controller-system">
@@ -116,6 +135,9 @@
         <i_min>-1</i_min>
         <cmd_max>100.0</cmd_max>
         <cmd_min>-100.0</cmd_min>
+        <xacro:if value="${initial_positions_file != ''}">
+          <initial_position>${initial_positions['Gripper']}</initial_position>
+        </xacro:if>
       </plugin>
     </xacro:if>
 

--- a/so_arm_100_description/urdf/so_arm_100_5dof.urdf.xacro
+++ b/so_arm_100_description/urdf/so_arm_100_5dof.urdf.xacro
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <robot name="so_arm_100_5dof" xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:arg name="prefix" default="" />
+  <xacro:arg name="initial_positions_file" default="" />
   <xacro:arg name="use_sim" default="false" />
   <xacro:arg name="use_topic_hardware_interface" default="false" />
   <xacro:arg name="use_fake_hardware" default="false" />
@@ -26,6 +27,7 @@
 
       <xacro:so_arm_100_5dof_gazebo
         prefix="$(arg prefix)"
+        initial_positions_file="$(arg initial_positions_file)"
         ros2_controllers_file="$(arg ros2_controllers_file)"
         use_topic_hardware_interface="$(arg use_topic_hardware_interface)" />
   </xacro:if>


### PR DESCRIPTION
This change allows an optional initial positions file to be passed to the Gazebo xacro.

### Details

Currently the Gazebo model, when using topic based control, initialises all the joints to zero on simulation start. This is ok for an arm afixed to a world plane, but may not be suitable when the arm is attached to a mobile robot, for example a quadcopter.

AFAIK Gazebo does not allow the initial state to be set in sdf (or at least the feature that is supposed to implement this is not working correctly). The next best alternative is to set the `<initial_position>` element of the joint controller system if these are used and the information is available. This is the approach taken in this PR. The arm will move to the desired initial state after the simulation starts and is unpaused.

_Example: arm fixed to world plane_

![08a-so-arm-world](https://github.com/user-attachments/assets/321f284b-4db9-42d7-bdad-83c22a9575db)

_Example: arm fixed to quad copter_

<img width="512" height="366" alt="08b-so-arm-copter" src="https://github.com/user-attachments/assets/0bb2fff9-1d32-4ff6-b135-3d49b6299ad8" />

<img width="512" height="367" alt="08c-so-arm-copter-rviz" src="https://github.com/user-attachments/assets/99689265-1a6a-4967-8bff-20f3498dea44" />
