### PR TITLE
Fixes for joint prefix and initial position

### DIFF
--- a/so_arm_100_bringup/so_arm_100_bringup/so_arm_100_5dof_cmd_relay.py
+++ b/so_arm_100_bringup/so_arm_100_bringup/so_arm_100_5dof_cmd_relay.py
@@ -40,10 +40,13 @@ class SOARM1005DofCommandRelay(Node):
         # Create publishers and subscriptions
         self.pubs = {}
         for joint_name, topic in JOINT_TOPICS.items():
+            prefixed_joint_name = f"{prefix}{joint_name}"
             prefixed_topic = f"{prefix}{topic}"
-            self.pubs[joint_name] = self.create_publisher(Float64, prefixed_topic, 10)
+            self.pubs[prefixed_joint_name] = self.create_publisher(
+                Float64, prefixed_topic, 10
+            )
         self.create_subscription(
-            JointState, "/robot_joint_commands", self.on_joint_command, 10
+            JointState, "robot_joint_commands", self.on_joint_command, 10
         )
 
     def on_joint_command(self, msg):

--- a/so_arm_100_description/gazebo/so_arm_100_5dof.gazebo.xacro
+++ b/so_arm_100_description/gazebo/so_arm_100_5dof.gazebo.xacro
@@ -1,6 +1,11 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="so_arm_100_5dof_gazebo" params="prefix initial_positions_file:=^|'' ros2_controllers_file:=^|'' use_topic_hardware_interface:=^|false">
+  <xacro:macro name="so_arm_100_5dof_gazebo"
+    params="
+      prefix
+      initial_positions_file:=^|''
+      ros2_controllers_file:=^|''
+      use_topic_hardware_interface:=^|false">
   <!--
   Parameters
       prefix: prefix for joints and links
@@ -61,7 +66,8 @@
         <cmd_max>100.0</cmd_max>
         <cmd_min>-100.0</cmd_min>
         <xacro:if value="${initial_positions_file != ''}">
-          <initial_position>${initial_positions['Shoulder_Rotation']}</initial_position>
+          <xacro:property name="joint_name" value="${prefix}Shoulder_Rotation"/>
+          <initial_position>${initial_positions[joint_name]}</initial_position>
         </xacro:if>
       </plugin>
       <plugin name="gz::sim::systems::JointPositionController"
@@ -76,7 +82,8 @@
         <cmd_max>100.0</cmd_max>
         <cmd_min>-100.0</cmd_min>
         <xacro:if value="${initial_positions_file != ''}">
-          <initial_position>${initial_positions['Shoulder_Pitch']}</initial_position>
+          <xacro:property name="joint_name" value="${prefix}Shoulder_Pitch"/>
+          <initial_position>${initial_positions[joint_name]}</initial_position>
         </xacro:if>
       </plugin>
       <plugin name="gz::sim::systems::JointPositionController"
@@ -91,7 +98,8 @@
         <cmd_max>100.0</cmd_max>
         <cmd_min>-100.0</cmd_min>
         <xacro:if value="${initial_positions_file != ''}">
-          <initial_position>${initial_positions['Elbow']}</initial_position>
+          <xacro:property name="joint_name" value="${prefix}Elbow"/>
+          <initial_position>${initial_positions[joint_name]}</initial_position>
         </xacro:if>
       </plugin>
       <plugin name="gz::sim::systems::JointPositionController"
@@ -106,7 +114,8 @@
         <cmd_max>100.0</cmd_max>
         <cmd_min>-100.0</cmd_min>
         <xacro:if value="${initial_positions_file != ''}">
-          <initial_position>${initial_positions['Wrist_Pitch']}</initial_position>
+          <xacro:property name="joint_name" value="${prefix}Wrist_Pitch"/>
+          <initial_position>${initial_positions[joint_name]}</initial_position>
         </xacro:if>
       </plugin>
       <plugin name="gz::sim::systems::JointPositionController"
@@ -121,7 +130,8 @@
         <cmd_max>100.0</cmd_max>
         <cmd_min>-100.0</cmd_min>
         <xacro:if value="${initial_positions_file != ''}">
-          <initial_position>${initial_positions['Wrist_Roll']}</initial_position>
+          <xacro:property name="joint_name" value="${prefix}Wrist_Roll"/>
+          <initial_position>${initial_positions[joint_name]}</initial_position>
         </xacro:if>
       </plugin>
       <plugin name="gz::sim::systems::JointPositionController"
@@ -136,7 +146,8 @@
         <cmd_max>100.0</cmd_max>
         <cmd_min>-100.0</cmd_min>
         <xacro:if value="${initial_positions_file != ''}">
-          <initial_position>${initial_positions['Gripper']}</initial_position>
+          <xacro:property name="joint_name" value="${prefix}Gripper"/>
+          <initial_position>${initial_positions[joint_name]}</initial_position>
         </xacro:if>
       </plugin>
     </xacro:if>

--- a/so_arm_100_description/ros2_control/so_arm_100_5dof_position.ros2_control.xacro
+++ b/so_arm_100_description/ros2_control/so_arm_100_5dof_position.ros2_control.xacro
@@ -4,6 +4,7 @@
     params="
       name
       prefix
+      initial_positions_file:=^|''
       use_sim:=^|false
       use_topic_hardware_interface:=^|false
       use_fake_hardware:=^|false
@@ -15,6 +16,7 @@
     Parameters
         name: name given to the controller system
         prefix: prefix for joints and links
+        initial_positions_file: initial positions file for joints
         use_sim: true if using Gazebo
         use_topic_hardware_interface: true if using topic based control
         use_fake_hardware: true if not use_sim and using fake hardware
@@ -23,6 +25,9 @@
         servo_speed: servo move speed in ticks/s
         servo_acceleration: servo move acceleration in ticks/s^2
     -->
+  <xacro:if value="${initial_positions_file != ''}">
+      <xacro:property name="initial_positions" value="${xacro.load_yaml(initial_positions_file)['initial_positions']}"/>
+  </xacro:if>
 
     <ros2_control name="${name}" type="system">
       <hardware>
@@ -55,6 +60,10 @@
         <command_interface name="position">
           <param name="min">-3.14</param>
           <param name="max">3.14</param>
+          <xacro:if value="${initial_positions_file != ''}">
+            <xacro:property name="joint_name" value="${prefix}Shoulder_Rotation"/>
+            <param name="initial_value">${initial_positions[joint_name]}</param>
+          </xacro:if>
         </command_interface>
         <state_interface name="position"/>
         <state_interface name="velocity"/>
@@ -64,6 +73,10 @@
         <command_interface name="position">
           <param name="min">-3.14</param>
           <param name="max">3.14</param>
+          <xacro:if value="${initial_positions_file != ''}">
+            <xacro:property name="joint_name" value="${prefix}Shoulder_Pitch"/>
+            <param name="initial_value">${initial_positions[joint_name]}</param>
+          </xacro:if>
         </command_interface>
         <state_interface name="position"/>
         <state_interface name="velocity"/>
@@ -73,6 +86,10 @@
         <command_interface name="position">
           <param name="min">-3.14</param>
           <param name="max">3.14</param>
+          <xacro:if value="${initial_positions_file != ''}">
+            <xacro:property name="joint_name" value="${prefix}Elbow"/>
+            <param name="initial_value">${initial_positions[joint_name]}</param>
+          </xacro:if>
         </command_interface>
         <state_interface name="position"/>
         <state_interface name="velocity"/>
@@ -82,6 +99,10 @@
         <command_interface name="position">
           <param name="min">-3.14</param>
           <param name="max">3.14</param>
+          <xacro:if value="${initial_positions_file != ''}">
+            <xacro:property name="joint_name" value="${prefix}Wrist_Pitch"/>
+            <param name="initial_value">${initial_positions[joint_name]}</param>
+          </xacro:if>
         </command_interface>
         <state_interface name="position"/>
         <state_interface name="velocity"/>
@@ -91,6 +112,10 @@
         <command_interface name="position">
           <param name="min">-3.14</param>
           <param name="max">3.14</param>
+          <xacro:if value="${initial_positions_file != ''}">
+            <xacro:property name="joint_name" value="${prefix}Wrist_Roll"/>
+            <param name="initial_value">${initial_positions[joint_name]}</param>
+          </xacro:if>
         </command_interface>
         <state_interface name="position"/>
         <state_interface name="velocity"/>
@@ -100,6 +125,10 @@
         <command_interface name="position">
           <param name="min">-0.1792</param>
           <param name="max">1.57</param>
+          <xacro:if value="${initial_positions_file != ''}">
+            <xacro:property name="joint_name" value="${prefix}Gripper"/>
+            <param name="initial_value">${initial_positions[joint_name]}</param>
+          </xacro:if>
         </command_interface>
         <state_interface name="position"/>
         <state_interface name="velocity"/>

--- a/so_arm_100_description/ros2_control/so_arm_100_5dof_position.ros2_control.xacro
+++ b/so_arm_100_description/ros2_control/so_arm_100_5dof_position.ros2_control.xacro
@@ -29,8 +29,8 @@
         <xacro:if value="${use_sim}">
           <xacro:if value="${use_topic_hardware_interface}">
             <plugin>joint_state_topic_hardware_interface/JointStateTopicSystem</plugin>
-            <param name="joint_commands_topic">/robot_joint_commands</param>
-            <param name="joint_states_topic">/robot_joint_states</param>
+            <param name="joint_commands_topic">robot_joint_commands</param>
+            <param name="joint_states_topic">robot_joint_states</param>
           </xacro:if>
           <xacro:unless value="${use_topic_hardware_interface}">
             <plugin>gz_ros2_control/GazeboSimSystem</plugin>


### PR DESCRIPTION
This PR contains a number of fixes when using a joint prefix and setting joint initial positions

### Details

- The `so_arm_100_5dof_cmd_relay` node used with topic based control in simulation was not using the prefixed joint names in the publisher dictionary which meant that joint commands were not forwarded correctly.
-  Similarly, `so_arm_100_5dof.gazebo.xacro` did not apply the prefix to the joint name when looking up initial positions from file.
-  Use relative topic names for the topic based controller in `so_arm_100_5dof_position.ros2_control.xacro` so that node namespaces will be applied correctly (if set).
- Use the initial positions file in `so_arm_100_5dof_position.ros2_control.xacro` to set the initial command. Otherwise the initial commanded position will default to the value zero.

### Testing

These changes have been tested in simulation with a copter + arm. In this case the arm must be initially folded under the copter and should not extend when the controllers are activated. The arm must use prefixes as the `base_link` collides with the corresponding link in the copter. 

With the changes the arm operates correctly and is compatible with MoveIt. Full namespace support, which is required to support multiple vehicles with arms,  is not currently working, and will be addressed in a future PR.

 
_Example: `so_arm_100` model on mobile base requiring `prefix:=arm_` to support composition._

![03-iris-arm-moveit](https://github.com/user-attachments/assets/9add349b-5ea4-4b90-8558-337dda890675)
