### PR TITLE
so_arm_100_bringup: cmd_relay: check message arrays are not empty

### DIFF
--- a/so_arm_100_bringup/so_arm_100_bringup/so_arm_100_5dof_cmd_relay.py
+++ b/so_arm_100_bringup/so_arm_100_bringup/so_arm_100_5dof_cmd_relay.py
@@ -53,10 +53,10 @@ class SOARM1005DofCommandRelay(Node):
         for i, name in enumerate(msg.name):
             if name in self.pubs:
                 cmd = Float64()
-                if not math.isnan(msg.position[i]):
+                if msg.position and not math.isnan(msg.position[i]):
                     # position command
                     cmd.data = msg.position[i]
-                elif not math.isnan(msg.velocity[i]):
+                elif msg.velocity and not math.isnan(msg.velocity[i]):
                     # velocity command
                     cmd.data = msg.velocity[i]
                 self.pubs[name].publish(cmd)


### PR DESCRIPTION
This PR fixes an issue where the relay node attempts to index into an empty array. The current version works with a patched version of [topic_based_hardware_interfaces](https://github.com/ros-controls/topic_based_hardware_interfaces) where the command arrays all have the same size:

- https://github.com/ros-controls/topic_based_hardware_interfaces/pull/101

This PR adds a check to the relay to ensure the arrays are not empty, and works with the package's `main` branch.